### PR TITLE
Fix: Add Handlebars comment to prevent parsing error

### DIFF
--- a/src/ai/flows/generate-scenario.ts
+++ b/src/ai/flows/generate-scenario.ts
@@ -178,7 +178,7 @@ Factor in new player stats: Energie (low means tired, high means active), Stress
 For complex actions implied by '{{{playerChoice}}}', describe the player's attempt and the observable situation in the narrative. The game system will determine the mechanical outcome.
 Use the PNJ's disposition score and interaction history to influence their dialogue, actions, and how they react to the player.
 If the player's actions should change a PNJ's disposition or add a significant memory, you can suggest an `updatedDispositionScore` and a `newInteractionLogEntry` for that PNJ in your response (using the `pnjInteractions` output field).
-{{/unless}}`;
+{{!}}{{/unless}}`;
 const PROMPT_PHASE_1_INFO_GATHERING = `
 **Phase 1: Strategic Information Gathering & API Management**
 {{#unless isInitialUnknownLocation}}


### PR DESCRIPTION
A JavaScript parsing error "Expression expected" was occurring at the location of an {{/unless}} tag within a large template literal string in src/ai/flows/generate-scenario.ts.

This change adds a Handlebars comment {{!}} immediately before the problematic {{/unless}} tag. This modification aims to help the JavaScript parser correctly interpret the end of the template literal without altering the Handlebars logic.